### PR TITLE
Render Access Denied Message and User Details on 403 Error Page

### DIFF
--- a/src/main/java/codegym/danang/demo/controller/MainController.java
+++ b/src/main/java/codegym/danang/demo/controller/MainController.java
@@ -60,6 +60,23 @@ public class MainController {
         return "userInfoPage";
     }
 
+    @RequestMapping(value = "/403", method = RequestMethod.GET)
+    public String accessDenied(Model model, Principal principal) {
 
+        if (principal != null) {
+            User loginedUser = (User) ((Authentication) principal).getPrincipal();
+
+            String userInfo = WebUtils.toString(loginedUser);
+
+            model.addAttribute("userInfo", userInfo);
+
+            String message = "Hi " + principal.getName() //
+                    + "<br> You do not have permission to access this page!";
+            model.addAttribute("message", message);
+
+        }
+
+        return "403Page";
+    }
 
 }


### PR DESCRIPTION
Purpose: Enhance the 403 error page to show a personalized access denied message and user information.

Changes:

Added logic to display user info and a custom error message when access is denied.
Updated the 403 error page to show the user's name and a friendly access denial message.
Impact:

Provides users with a clear and personalized message when they lack access permissions.